### PR TITLE
Remove review checkboxes, fix keyword handling, add One Shot

### DIFF
--- a/js/keywords.js
+++ b/js/keywords.js
@@ -15,6 +15,7 @@ export const keywordSuggestions = [
 	"Indirect Fire",
 	"Extra Attacks",
 	"Conversion",
+	"One Shot",
 ];
 
 export const keywordsWithSuffix = [
@@ -86,10 +87,33 @@ export function setupKeywordInput(container) {
 		});
 	}
 
-	// Helper: create tag safely (no duplicates)
+	// Helper: create tag safely (no duplicates, updates suffix numbers)
 	function addTag(value) {
 		const trimmed = value.trim();
 		if (!trimmed) return;
+
+		// Block keywords that still have [X] placeholder
+		if (/\[x\]/i.test(trimmed)) return;
+
+		// Check if this is a suffixed keyword and find existing tag with same base
+		const base = keywordsWithSuffix.find(
+			kw => trimmed.toLowerCase().startsWith(kw.toLowerCase())
+		);
+
+		if (base) {
+			const existingTag = [...tagsDiv.querySelectorAll(".tag")]
+				.find(t => t.textContent.toLowerCase().startsWith(base.toLowerCase()));
+
+			if (existingTag) {
+				// Update the existing tag's number instead of adding a duplicate
+				existingTag.textContent = trimmed;
+				existingTag.classList.remove("hidden");
+				existingTag.classList.add("revealed");
+				existingTag.onclick = () => existingTag.remove();
+				input.value = "";
+				return;
+			}
+		}
 
 		const tag = [...tagsDiv.querySelectorAll(".tag")]
 			.find(t => t.textContent.toLowerCase() === trimmed.toLowerCase());
@@ -117,7 +141,8 @@ export function setupKeywordInput(container) {
 			kw => kw.toLowerCase() === val.toLowerCase()
 		);
 
-		if (match) addTag(match);
+		// Don't auto-accept suffixed placeholders like "Sustained Hits [X]"
+		if (match && !/\[x\]/i.test(match)) addTag(match);
 	});
 
 	// Handle Enter / Tab / selection

--- a/js/review.js
+++ b/js/review.js
@@ -1,4 +1,4 @@
-import { units, testSettings, setPageState } from './state.js';
+import { units, setPageState } from './state.js';
 import { sanitizeValue, autoSizeAllTextareas } from './helpers.js';
 import { startFlashcards } from './flashcards.js';
 
@@ -62,17 +62,7 @@ export function displayReviewForm() {
 	unitCharacteristics.forEach(k => {
 		const c = document.createElement("div");
 		c.className = "header-cell";
-
-		const chk = document.createElement("input");
-		chk.type = "checkbox";
-		chk.checked = true;
-		chk.addEventListener("change", e => {
-			if (e.target.checked) testSettings.excludedColumns.delete(k);
-			else testSettings.excludedColumns.add(k);
-		});
-
-		c.appendChild(chk);
-		c.append(" " + k);
+		c.textContent = k;
 		unitHeadRow.appendChild(c);
 	});
 
@@ -85,18 +75,7 @@ export function displayReviewForm() {
 
 		const uNameCell = document.createElement("div");
 		uNameCell.className = "cell unit-left";
-
-		const chk = document.createElement("input");
-		chk.type = "checkbox";
-		chk.checked = true;
-		chk.addEventListener("change", e => {
-			const name = unit.name;
-			if (e.target.checked) testSettings.excludedUnits.delete(name);
-			else testSettings.excludedUnits.add(name);
-		});
-
-		uNameCell.appendChild(chk);
-		uNameCell.append(" " + unit.name);
+		uNameCell.textContent = unit.name;
 		uRow.appendChild(uNameCell);
 
 		unitCharacteristics.forEach(key => {
@@ -177,17 +156,7 @@ export function displayReviewForm() {
 		allKeys.forEach(k => {
 			const c = document.createElement("div");
 			c.className = "header-cell";
-
-			const chk = document.createElement("input");
-			chk.type = "checkbox";
-			chk.checked = true;
-			chk.addEventListener("change", e => {
-				if (e.target.checked) testSettings.excludedColumns.delete(k);
-				else testSettings.excludedColumns.add(k);
-			});
-
-			c.appendChild(chk);
-			c.append(" " + k);
+			c.textContent = k;
 			weaponHeadRow.appendChild(c);
 		});
 		weaponTable.appendChild(weaponHeadRow);


### PR DESCRIPTION
- Remove all checkbox toggles from review form (unit names, unit characteristics, weapon characteristics)
- Fix duplicate suffixed keywords: when a user enters e.g. "Sustained Hits 2" and "Sustained Hits 1" already exists, update the existing tag instead of adding a duplicate
- Block accepting keywords with [X] placeholder — user must provide an actual number before the keyword is recorded
- Add "One Shot" to the keyword suggestions list

https://claude.ai/code/session_01CdhYXru9GBJt3tqckZG4PY